### PR TITLE
Add mul(), round(), floor(), ceil(), and sign() to Vec2 and Vec3 classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG.md
 
+## Unreleased changes
+
+- `Vec2`, `Vec3` クラスに `mul()`, `round()`, `floor()`, `ceil()`, `sign()` を追加。
+
 ## 1.0.1
 
 - ドキュメンテーションコメント中、角度の単位をradian出なくdegreeと誤って説明している箇所の修正。

--- a/src/__tests__/math/Vec2Spec.ts
+++ b/src/__tests__/math/Vec2Spec.ts
@@ -82,6 +82,13 @@ describe("Vec2", () => {
         expect(v.y).toEqual(4);
     });
 
+    it("muls", () => {
+        const v = new Vec2(1, 2);
+        v.mul({ x: 3, y: -4 });
+        expect(v.x).toEqual(3);
+        expect(v.y).toEqual(-8);
+    });
+
     it("dots", () => {
         const v = new Vec2(1, 2);
         expect(v.dot({ x: 2, y: 4 })).toEqual(10);
@@ -120,11 +127,39 @@ describe("Vec2", () => {
         expect(v.y).toEqual(4 / 5);
     });
 
-    it("negate", () => {
+    it("negates", () => {
         const v = new Vec2(3, -4);
         v.negate();
         expect(v.x).toEqual(-3);
         expect(v.y).toEqual(4);
+    });
+
+    it("rounds", () => {
+        const v = new Vec2(2.4, -4.7);
+        v.round();
+        expect(v.x).toEqual(2);
+        expect(v.y).toEqual(-5);
+    });
+
+    it("floors", () => {
+        const v = new Vec2(2.4, -4.7);
+        v.floor();
+        expect(v.x).toEqual(2);
+        expect(v.y).toEqual(-5);
+    });
+
+    it("ceils", () => {
+        const v = new Vec2(2.4, -4.7);
+        v.ceil();
+        expect(v.x).toEqual(3);
+        expect(v.y).toEqual(-4);
+    });
+
+    it("signs", () => {
+        const v = new Vec2(2.4, -0);
+        v.sign();
+        expect(v.x).toEqual(1);
+        expect(v.y).toEqual(-0);
     });
 
     it("rotates", () => {

--- a/src/__tests__/math/Vec3Spec.ts
+++ b/src/__tests__/math/Vec3Spec.ts
@@ -89,6 +89,14 @@ describe("Vec3", () => {
         expect(v.z).toEqual(6);
     });
 
+    it("muls", () => {
+        const v = new Vec3(1, 2, 3);
+        v.mul({ x: 4, y: -5, z: 6 });
+        expect(v.x).toEqual(4);
+        expect(v.y).toEqual(-10);
+        expect(v.z).toEqual(18);
+    });
+
     it("dots", () => {
         const v = new Vec3(1, 2, 3);
         expect(v.dot({ x: 2, y: 4, z: 6 })).toEqual(28);
@@ -137,12 +145,44 @@ describe("Vec3", () => {
         expect(v.z).toEqual(4 / 6);
     });
 
-    it("negate", () => {
+    it("negates", () => {
         const v = new Vec3(3, -4, 5);
         v.negate();
         expect(v.x).toEqual(-3);
         expect(v.y).toEqual(4);
         expect(v.z).toEqual(-5);
+    });
+
+    it("rounds", () => {
+        const v = new Vec3(2.4, -4.7, 1.5);
+        v.round();
+        expect(v.x).toEqual(2);
+        expect(v.y).toEqual(-5);
+        expect(v.z).toEqual(2);
+    });
+
+    it("floors", () => {
+        const v = new Vec3(2.4, -4.7, 1.5);
+        v.floor();
+        expect(v.x).toEqual(2);
+        expect(v.y).toEqual(-5);
+        expect(v.z).toEqual(1);
+    });
+
+    it("ceils", () => {
+        const v = new Vec3(2.4, -4.7, 1.5);
+        v.ceil();
+        expect(v.x).toEqual(3);
+        expect(v.y).toEqual(-4);
+        expect(v.z).toEqual(2);
+    });
+
+    it("signs", () => {
+        const v = new Vec3(2.4, -2.4, -0);
+        v.sign();
+        expect(v.x).toEqual(1);
+        expect(v.y).toEqual(-1);
+        expect(v.z).toEqual(-0);
     });
 
     it("rotates about X asis", () => {

--- a/src/math/Vec2.ts
+++ b/src/math/Vec2.ts
@@ -328,7 +328,7 @@ export class Vec2 {
 	}
 
 	/**
-	 * 角要素を符号を表す +/- 1, +/- 0 にする。
+	 * 各要素を符号を表す +/- 1, +/- 0 にする。
 	 */
 	sign(): this {
 		this.x = Math.sign(this.x);

--- a/src/math/Vec2.ts
+++ b/src/math/Vec2.ts
@@ -199,6 +199,17 @@ export class Vec2 {
 	}
 
 	/**
+	 * アダマール積を求める。
+	 *
+	 * @param v ベクトル。
+	 */
+	mul(v: Vec2Like): this {
+		this.x = this.x * v.x;
+		this.y = this.y * v.y;
+		return this;
+	}
+
+	/**
 	 * 内積を求める。
 	 *
 	 * @param v ベクトル。
@@ -286,6 +297,42 @@ export class Vec2 {
 	negate(): this {
 		this.x *= -1;
 		this.y *= -1;
+		return this;
+	}
+
+	/**
+	 * 四捨五入する。
+	 */
+	round(): this {
+		this.x = Math.round(this.x);
+		this.y = Math.round(this.y);
+		return this;
+	}
+
+	/**
+	 * 小数点以下を切り捨てる。
+	 */
+	floor(): this {
+		this.x = Math.floor(this.x);
+		this.y = Math.floor(this.y);
+		return this;
+	}
+
+	/**
+	 * 小数点以下を切り上げる。
+	 */
+	ceil(): this {
+		this.x = Math.ceil(this.x);
+		this.y = Math.ceil(this.y);
+		return this;
+	}
+
+	/**
+	 * 角要素を符号を表す +/- 1, +/- 0 にする。
+	 */
+	sign(): this {
+		this.x = Math.sign(this.x);
+		this.y = Math.sign(this.y);
 		return this;
 	}
 

--- a/src/math/Vec3.ts
+++ b/src/math/Vec3.ts
@@ -217,6 +217,18 @@ export class Vec3 {
 	}
 
 	/**
+	 * アダマール積を求める。
+	 *
+	 * @param v ベクトル。
+	 */
+	 mul(v: Vec3Like): this {
+		this.x = this.x * v.x;
+		this.y = this.y * v.y;
+		this.z = this.z * v.z;
+		return this;
+	}
+
+	/**
 	 * 内積を求める。
 	 *
 	 * @param v ベクトル。
@@ -316,6 +328,46 @@ export class Vec3 {
 		this.x *= -1;
 		this.y *= -1;
 		this.z *= -1;
+		return this;
+	}
+
+	/**
+	 * 四捨五入する。
+	 */
+	 round(): this {
+		this.x = Math.round(this.x);
+		this.y = Math.round(this.y);
+		this.z = Math.round(this.z);
+		return this;
+	}
+
+	/**
+	 * 小数点以下を切り捨てる。
+	 */
+	floor(): this {
+		this.x = Math.floor(this.x);
+		this.y = Math.floor(this.y);
+		this.z = Math.floor(this.z);
+		return this;
+	}
+
+	/**
+	 * 小数点以下を切り上げる。
+	 */
+	ceil(): this {
+		this.x = Math.ceil(this.x);
+		this.y = Math.ceil(this.y);
+		this.z = Math.ceil(this.z);
+		return this;
+	}
+
+	/**
+	 * 各要素を符号を表す +/- 1, +/- 0 にする。
+	 */
+	sign(): this {
+		this.x = Math.sign(this.x);
+		this.y = Math.sign(this.y);
+		this.z = Math.sign(this.z);
 		return this;
 	}
 


### PR DESCRIPTION
`Vec2`, `Vec3` クラスに以下の関数を追加します。

- `mul()` アダマール積
- `round()` 四捨五入
- `floor()` 切り捨て
- `ceil()` 切り上げ
- `sign()` 符号を表す+-1,+-0 への変換